### PR TITLE
Enable content hashing for WASM files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,4 +25,5 @@ bin-default-features = false
 bin-features = ["ssr"]
 lib-default-features = false
 lib-features = ["hydrate"]
+hash-files = true
 # working-directory = "crates/web"


### PR DESCRIPTION
Add hash-files = true to Leptos configuration to enable content-based
hashing for compiled CSS, JS, and WASM files. This resolves Safari's
aggressive caching of web.wasm by generating unique filenames like
web-abc123.wasm whenever the content changes.

Fixes cache busting issue in development and production environments.