### PR TITLE
Fix mobile layout by stacking panels vertically

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -105,7 +105,7 @@ export function App() {
             Configure your actuator plate specifications to generate STEP and glTF files.
           </CardDescription>
         </CardHeader>
-        <CardContent className="flex gap-4">
+        <CardContent className="flex flex-col lg:flex-row gap-4">
           <div className="flex-1 min-w-0">
             <div className="w-full aspect-square min-h-96">
               {modelSrc ? (


### PR DESCRIPTION
Updates the CardContent flex layout to use responsive classes:
- flex-col: Stack vertically on mobile (default)
- lg:flex-row: Display side-by-side on large screens

This fixes issue #34 where panels were cramped on mobile devices.
The model viewer and form now stack vertically on mobile for
better usability on iOS Safari and other mobile browsers.