### PR TITLE
Improve mobile responsiveness across all layout elements

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -92,8 +92,8 @@ export function App() {
   };
 
   return (
-    <div className="container mx-auto p-8 text-center relative z-10">
-      <div className="absolute top-11 right-11">
+    <div className="container mx-auto p-4 lg:p-8 text-center relative z-10">
+      <div className="absolute top-4 right-4 lg:top-11 lg:right-11">
         <ThemePicker />
       </div>
       <Card>
@@ -107,7 +107,7 @@ export function App() {
         </CardHeader>
         <CardContent className="flex flex-col lg:flex-row gap-4">
           <div className="flex-1 min-w-0">
-            <div className="w-full aspect-square min-h-96">
+            <div className="w-full aspect-square min-h-64 lg:min-h-96">
               {modelSrc ? (
                 <ModelViewer src={modelSrc} alt="Actuator plate model" />
               ) : (
@@ -127,7 +127,7 @@ export function App() {
           </div>
           <div className="flex-1 min-w-0">
             <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-              <div className="grid grid-cols-2 auto-rows-auto gap-4">
+              <div className="grid grid-cols-1 sm:grid-cols-2 auto-rows-auto gap-4">
                 <Combined
                   forProp="boltSpacing"
                   name="Bolt Spacing"


### PR DESCRIPTION
Addresses remaining mobile UX issues from #34:

- Reduce container padding on mobile (p-4 vs p-8)
- Adjust ThemePicker position for mobile (top-4 right-4 vs top-11 right-11)
- Scale down model viewer minimum height on mobile (min-h-64 vs min-h-96)
- Use single column form layout on mobile (grid-cols-1 vs grid-cols-2)

These changes ensure the app is fully usable on mobile devices with appropriate spacing, touch targets, and field widths.