### PR TITLE
Fix stale and incorrect documentation across markdown files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,6 +172,8 @@ The server runs on port 3030 and serves:
 - API endpoints at `/api/*`
 - Frontend at all other routes
 
+**Production URL**: https://platerator.newschematic.org
+
 ## CI/CD
 
 ### GitHub Actions Workflows
@@ -179,14 +181,14 @@ The server runs on port 3030 and serves:
 The project uses GitHub Actions for continuous integration and deployment:
 
 **CI Workflow** (`.github/workflows/ci.yml`):
-- Runs on all pull requests targeting master
+- Runs on all pull requests targeting master and on pushes to master
 - **test-rust**: Runs `cargo test`, `cargo clippy`, and `scripts/check-api-sync.sh`
-- **test-frontend**: Builds frontend to catch TypeScript errors
+- **test-frontend**: Builds WASM module, type-checks frontend, and builds frontend
 
 **Build Workflow** (`.github/workflows/build.yml`):
-- Runs on pushes to master
+- Runs on pushes to master and via `workflow_dispatch`
 - **test**: Runs all tests and clippy
-- **build**: Builds the release binary for deployment to Lightsail
+- **build**: Builds Rust binary + WASM + frontend, packages them into a tarball (binary, `dist/`, KCL files), uploads as a 30-day GitHub Actions artifact, and publishes a GitHub release if a `v*` tag is pushed. Deployment to Lightsail is manual from the artifact.
 
 ### IMPORTANT: Cache Busting When Adding Dependencies
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -145,7 +145,7 @@ git commit -m "Deploy to production"
 git push origin master
 
 # This triggers GitHub Actions to build the Linux binary
-# Check progress at: https://github.com/yourusername/steel-thread/actions
+# Check progress at: https://github.com/chrisbodhi/steel-thread/actions
 ```
 
 Wait for the build to complete (~5 minutes).

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -66,7 +66,7 @@ git commit -m "Initial deployment"
 git push origin master
 
 # Wait for GitHub Actions (~5 min)
-# Check: https://github.com/yourusername/steel-thread/actions
+# Check: https://github.com/chrisbodhi/steel-thread/actions
 
 # Download build and deploy
 just deploy

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ An actuator plate configurator exploring web → parametric CAD → quote pipeli
 - [Rust](https://rustup.rs/) (latest stable)
 - [Bun](https://bun.sh/) (JavaScript runtime)
 - [Just](https://github.com/casey/just) (command runner) - install via `cargo install just` or `brew install just`
-- [Terraform](https://...) (IaC)
-- [AWS CLI](https://...) (Cloud provider)
+- [Terraform](https://developer.hashicorp.com/terraform/install) (IaC)
+- [AWS CLI](https://aws.amazon.com/cli/) (Cloud provider)
 
 ## Quick Start
 
@@ -140,7 +140,7 @@ See [QUICKSTART.md](./QUICKSTART.md) for step-by-step guide.
 Platerator includes interactive OpenAPI (Swagger) documentation:
 
 **Development**: http://localhost:3030/api/docs
-**Production**: https://your-domain.com/api/docs
+**Production**: https://platerator.newschematic.org/api/docs
 
 The Swagger UI provides:
 - Complete API endpoint documentation

--- a/TESTING.md
+++ b/TESTING.md
@@ -6,16 +6,19 @@ This project has comprehensive test coverage across multiple layers.
 
 ```
 crates/
+├── domain/
+│   └── src/lib.rs              # Domain type tests (14 tests)
 ├── validation/
-│   └── src/lib.rs              # Unit tests for validation logic (18 tests)
+│   └── src/lib.rs              # Unit tests for validation logic (55 tests)
 ├── parametric/
 │   └── src/lib.rs              # Parametric generation tests (4 fast + 3 ignored)
 └── web/
+    ├── src/                    # Cache/session unit tests (5 tests)
     └── tests/
         └── api_tests.rs        # Integration tests for REST API (6 tests)
 ```
 
-**Total: 28 fast tests + 3 ignored integration tests**
+**Total: ~82 fast tests + 3 ignored integration tests** (see CLAUDE.md for current count)
 
 ## Running Tests
 
@@ -24,7 +27,7 @@ crates/
 cargo test
 
 # Run tests for a specific crate
-cargo test -p validation      # Validation only (18 tests)
+cargo test -p validation      # Validation only (55 tests)
 cargo test -p parametric      # Parametric tests (4 fast tests, skips 3 zoo CLI tests)
 cargo test -p web             # API tests only (6 tests)
 
@@ -173,16 +176,10 @@ async fn test_generate_endpoint_invalid_plate() {
 
 ## What's Not Tested (Yet)
 
-### Server Functions
-- The `#[server]` functions are harder to test in isolation
-- They're implicitly tested through the web UI
-- Could add end-to-end tests using browser automation
-
-### Component Tests
-- Leptos components are challenging to unit test
+### Frontend Component Tests
+- React components have no unit tests currently
 - Consider:
-  - Browser-based testing (Playwright, Cypress)
-  - Component testing with `wasm-bindgen-test`
+  - Browser-based E2E testing (Playwright, Cypress)
   - Visual regression testing
 
 ### Future Test Ideas
@@ -228,9 +225,6 @@ serde_json = "1.0"
 # Example GitHub Actions
 - name: Run tests
   run: cargo test --workspace --verbose
-
-- name: Run tests with features
-  run: cargo test -p web --features ssr
 ```
 
 ## Best Practices

--- a/crates/validation/README.md
+++ b/crates/validation/README.md
@@ -62,8 +62,8 @@ The WASM module is automatically built as part of:
 ### Bolt Spacing
 - Must be greater than 0
 
-### Bolt Diameter
-- Must be greater than 0
+### Bolt Size
+- Must be a valid ISO metric size (M3, M4, M5, M6, M8, M10, M12)
 
 ### Bracket Height
 - Must be greater than 0


### PR DESCRIPTION
- Correct CI/build workflow descriptions to match actual .github/workflows
- Add production URL (platerator.newschematic.org) to CLAUDE.md and README.md
- Fix broken placeholder links for Terraform and AWS CLI in README.md
- Replace yourusername placeholder with chrisbodhi in QUICKSTART.md and DEPLOYMENT.md
- Remove Leptos references from TESTING.md (project uses React, not Leptos)
- Update stale test counts in TESTING.md to reflect current codebase
- Fix validation README: "Bolt Diameter" → "Bolt Size" with correct ISO metric rule